### PR TITLE
Update voting strategy to new weighted score

### DIFF
--- a/src/strategies/gamium-voting/index.ts
+++ b/src/strategies/gamium-voting/index.ts
@@ -114,7 +114,7 @@ export async function strategy(
           formatUnits(stakingPairResponse[address], options.decimals)
         ) *
         (1 + liquidityPoolTokenRatio);
-      return [address, tokenBalance + stakingTokenBalance + stakingPairBalance];
+      return [address, tokenBalance + 2 * stakingTokenBalance + 2 * stakingPairBalance];
     })
   );
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- With the previous Voting System, 1 GMM = 1 vote, regardless of whether it’s staked or not. This means that now, the voting weight in Gamium DAO proposals is the same for all DAO members, regardless of whether they have their GMM at stake or not.
- The new voted system apply the following changes: Vote value from 1 non-staked GMM = 1 vote, Vote value from 1 staked GMM= 2 votes

